### PR TITLE
Bump versions of npm packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install release dependencies
         run: |
           npm install semantic-release@^24.0.0 \
-          @semantic-release/git@^10.0.1 semantic-release-factorio@^1.5.0 \
+          @semantic-release/git@^10.0.1 semantic-release-factorio@^1.5.1 \
           conventional-changelog-conventionalcommits-factorio@^1.1.0
       - name: Run semantic-release
         run: npx semantic-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,16 +13,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: lts/*
       - name: Install release dependencies
         run: |
-          npm install semantic-release@^20.0.2 \
+          npm install semantic-release@^24.0.0 \
           @semantic-release/git@^10.0.1 semantic-release-factorio@^1.5.0 \
-          conventional-changelog-conventionalcommits-factorio@^1.0.3
+          conventional-changelog-conventionalcommits-factorio@^1.1.0
       - name: Run semantic-release
         run: npx semantic-release
         env:


### PR DESCRIPTION
 to fix warning about node16 vs node20:
> "Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-node@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/."

PS: didn't run the new pipeline yet